### PR TITLE
Add script for get it working on Windows 10

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,20 @@ Compared to the original ITC XOP it has the following enhancements:
 ## Running requirements
 Minimum Igor Pro versions are 6.3 for 32bit and 7.0 for 64bit.
 
+## Windows 10
+
+Out of the box the ITCXOP2 does only run in the 32bit version on Windows 10.
+The reason is that there seems to be an issue in the combination of the
+ITCMM.DLL (the vendor library which the ITCXOP2 uses) and a security feature
+called `ASLR` which is enabled by default starting with Windows 10.
+
+Luckily by disabling ASLR for Igor Pro the ITCXOP2 works again.
+
+Steps:
+- Right-click "tools\\Disable-ASLR-for-IP7-and-8.ps1" and choose "Run" and
+  choose yes when asked for administrative permissions.
+- Restart Igor Pro
+
 ## Compilation instructions
 
 Required additional software:

--- a/tools/Disable-ASLR-for-IP7-and-8.ps1
+++ b/tools/Disable-ASLR-for-IP7-and-8.ps1
@@ -1,0 +1,2 @@
+$sh = new-object -com 'Shell.Application'
+$sh.ShellExecute('powershell', "-Command `"Set-ProcessMitigation -PolicyFilePath $PSScriptRoot\Settings.xml`"", '', 'runas')

--- a/tools/Settings.xml
+++ b/tools/Settings.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MitigationPolicy>
+  <AppConfig Executable="C:\Program Files\WaveMetrics\Igor Pro 8 Folder\IgorBinaries_Win32\Igor.exe">
+    <ASLR BottomUp="false" HighEntropy="false" />
+  </AppConfig>
+  <AppConfig Executable="C:\Program Files\WaveMetrics\Igor Pro 8 Folder\IgorBinaries_x64\Igor64.exe">
+    <ASLR BottomUp="false" HighEntropy="false" />
+  </AppConfig>
+  <AppConfig Executable="C:\Program Files\WaveMetrics\Igor Pro 7 Folder\IgorBinaries_Win32\Igor.exe">
+    <ASLR BottomUp="false" HighEntropy="false" />
+  </AppConfig>
+  <AppConfig Executable="C:\Program Files\WaveMetrics\Igor Pro 7 Folder\IgorBinaries_x64\Igor64.exe">
+    <ASLR BottomUp="false" HighEntropy="false" />
+  </AppConfig>
+</MitigationPolicy>


### PR DESCRIPTION
Under Windows 10 the ITC hardware does not work out of the box with
64bit Igor Pro.

The reason is that ASLR, see
https://de.wikipedia.org/wiki/Address_Space_Layout_Randomization, is
enabled by default and as it turns out breaks the ITCMM.dll in this
case.

Add a script to disable ASLR for Igor Pro 7 and 8. This assumes a
installation in the default folder of Igor Pro.

See
https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-exploit-guard/enable-exploit-protection#powershell
for some background on the powershell code.