### PR TITLE
Add PS script to fix Office365 preventing ITC registry import working correctly

### DIFF
--- a/tools/FixOffice365.ps1
+++ b/tools/FixOffice365.ps1
@@ -1,0 +1,13 @@
+$ErrorActionPreference = "stop"
+New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR | Out-Null
+Try {
+    $officeVer = (Get-ItemProperty -Path HKCR:\Word.Application\CurVer)."(Default)"
+}
+Catch {
+    exit
+}
+if ($officeVer -eq "Word.Application.16") {
+    $acl = (Get-Item HKLM:\SOFTWARE\Wow6432Node).GetAccessControl('Access')
+    $acl.SetSecurityDescriptorSddlForm($acl.Sddl.Replace("D:(","D:AI("))
+    Set-Acl -Path HKLM:\SOFTWARE\Wow6432Node $acl
+}


### PR DESCRIPTION
- ITC registry import for 64 bit is prevented to work properly
  due to a MS bug described here

https://answers.microsoft.com/en-us/office/forum/office_2016-office_install/registry-keys-in-hklmsoftwarewow6432node-are/c15da441-cf0c-4bb7-b193-e6cae4adcd50?page=2

- The script applies the first workaround if the registry indicates an
  installed office with version 16.

The issue was reported here: https://github.com/AllenInstitute/MIES/issues/428