### PR TITLE
MakeDestWave: Fix free wave checking

### DIFF
--- a/src/HelperFunctions.h
+++ b/src/HelperFunctions.h
@@ -129,7 +129,7 @@ void MakeDestWave(T p, waveHndl *destWaveH, int dataType, const int numRows,
   if(p->FREEFlagEncountered)
   {
     // Only allow /FREE flag if called from function
-    if(!p->calledFromFunction)
+    if((!p->calledFromFunction && !p->tp) || p->calledFromMacro)
     {
       throw IgorException(FREE_FLAG_ALLOWED_IN_FUNCTIONS_ONLY);
     }

--- a/tests/ITCTesting.ipf
+++ b/tests/ITCTesting.ipf
@@ -35,6 +35,7 @@
 #include ":Test_ITCUpdateFIFOPosition2"
 #include ":Test_ITCUpdateFIFOPositionAll2"
 #include ":Test_ITCWriteDigital2"
+#include ":Test_ITCGetVersions2"
 
 Function Run()
 	RunTest(WinList("Test_*.ipf", ";", "WIN:128"))

--- a/tests/Test_ITCGetVersions2.ipf
+++ b/tests/Test_ITCGetVersions2.ipf
@@ -1,0 +1,47 @@
+﻿#pragma TextEncoding = "UTF-8"	// For details execute DisplayHelpTopic "The TextEncoding Pragma"
+#pragma rtGlobals=3		          // Use modern global access method and strict wave access.
+#pragma ModuleName=Test_GetVersions2
+
+// This file is part of the `ITCXOP2` project and licensed under BSD-3-Clause.
+
+// available from https://github.com/byte-physics/igor-unit-testing-framework
+#include "unit-testing"
+
+// This also tests the logic for not allowing /FREE in Macros but allowing it in functions
+
+static Function Works()
+
+	ITCGetVersions2/FREE versions
+	CHECK_WAVE(versions, TEXT_WAVE | FREE_WAVE)
+End
+
+threadsafe static Function/WAVE WorksInThreadsafeFunctionImpl()
+
+	ITCGetVersions2/FREE versions
+
+	return versions
+End
+
+static Function WorksInThreadsafeFunction()
+
+	WAVE versions = WorksInThreadsafeFunctionImpl()
+	CHECK_WAVE(versions, TEXT_WAVE | FREE_WAVE)
+End
+
+Macro ComplainsInMacroImpl()
+
+	ITCGetVersions2/FREE/Z=1 versions
+EndMacro
+
+static Function ComplainsInMacro()
+
+	Execute/Z/Q "variable/G V_ITCError = NaN, V_ITCXOPError = NaN"
+	Execute/Z/Q "ComplainsInMacroImpl()"
+	NVAR/Z V_ITCError, V_ITCXOPError
+	CHECK(NVAR_Exists(V_ITCError))
+	CHECK(NVAR_Exists(V_ITCXOPError))
+	CHECK_EQUAL_VAR(V_ITCError, 0)
+	CHECK_EQUAL_VAR(V_ITCXOPError, 6109)
+	WAVE/Z versions
+	CHECK_WAVE(versions, NULL_WAVE)
+End


### PR DESCRIPTION
The fix in ea7b5f14 (MakeDestWave: Fix logic for /FREE flag, 2022-05-26)
was broken as IP9 r39103 does currently set
p->calledFromFunction to zero when called from threadsafe functions.

This is reported to WaveMetrics in #4195.

For now we fix it back, but also handle macros correctly.

And add tests.