### PR TITLE
RegisterITCSetGlobals2: Define standard output variables

### DIFF
--- a/src/RegisterOperations.cpp
+++ b/src/RegisterOperations.cpp
@@ -454,7 +454,7 @@ int RegisterITCSetGlobals2(void)
   // ITCSetGlobals2RuntimeParams structure as well.
   cmdTemplate       = "ITCSetGlobals2/Z[=number:displayErrors]/"
                       "D[=number:debugOutput]/LTS=string:logTemplateString";
-  runtimeNumVarList = "";
+  runtimeNumVarList = EXCEPTION_VARS;
   runtimeStrVarList = "";
   return RegisterOperation(cmdTemplate, runtimeNumVarList, runtimeStrVarList,
                            sizeof(ITCSetGlobals2RuntimeParams),

--- a/tests/Test_ITCSetGlobals2.ipf
+++ b/tests/Test_ITCSetGlobals2.ipf
@@ -62,7 +62,9 @@ End
 
 static Function noFlag()
 	ITCSetGlobals2
-	PASS()
+
+	CHECK_EQUAL_VAR(V_ITCError, 0)
+	CHECK_EQUAL_VAR(V_ITCXOPError, 0)
 End
 
 static Function zFlag()
@@ -70,7 +72,9 @@ static Function zFlag()
 	ITCSetGlobals2/Z
 	ITCSetGlobals2/Z=0
 	ITCSetGlobals2/Z=1
-	PASS()
+
+	CHECK_EQUAL_VAR(V_ITCError, 0)
+	CHECK_EQUAL_VAR(V_ITCXOPError, 0)
 End
 
 static Function dFlag()
@@ -78,7 +82,9 @@ static Function dFlag()
 	ITCSetGlobals2/D
 	ITCSetGlobals2/D=0
 	ITCSetGlobals2/D=1
-	PASS()
+
+	CHECK_EQUAL_VAR(V_ITCError, 0)
+	CHECK_EQUAL_VAR(V_ITCXOPError, 0)
 End
 
 static Function/WAVE InvalidLoggingTemplates()
@@ -97,9 +103,12 @@ static Function LTSFlagInvalidTemplate([string str])
 		ITCSetGlobals2/LTS=str; AbortONRTE
 		FAIL()
 	catch
-		err = GetRTError(1)
-		PASS()
+		CHECK_GT_VAR(GetRTError(1), 0)
 	endtry
+
+	ITCSetGlobals2/LTS=str/Z
+	CHECK_EQUAL_VAR(V_ITCError, 0)
+	CHECK_GT_VAR(V_ITCXOPError, 0)
 End
 
 static Function LTSFlagWorks()


### PR DESCRIPTION
The macros BEGIN_OUTER_CATCH/END_OUTER_CATCH require that the standard exception variables V_ITCError and V_ITCXOPError are defined for the operation.

Oddly enough IP9 [1] creates global variables if these are not defined.

[1]: IGORVERS:9.06
     BUILD:56657
     COMMIT:4a46fb8a46